### PR TITLE
make `options` calls "inheritable"

### DIFF
--- a/lib/nagare.rb
+++ b/lib/nagare.rb
@@ -23,6 +23,7 @@ module Nagare
 
     def self.inherited(base)
       base.instance_variable_set(:@attributes, @attributes.dup) if @attributes
+      base.instance_variable_set(:@options, @options.dup) if @options
 
       super
     end


### PR DESCRIPTION
if you have a descendant class from a base where options is called, your descendant will not inherit the `options` that were set on the base. which is maybe how you intended this to work, but it's surprising